### PR TITLE
feat:update tech-stack-grid section

### DIFF
--- a/src/components/sections/TechStack/index.tsx
+++ b/src/components/sections/TechStack/index.tsx
@@ -20,34 +20,43 @@ const TechStackGrid: React.FC = () => {
   console.log("Visible TechItems", filteredTechItems);
 
   return (
-    <div>
-      <div className="flex gap-2 mb-4">
-        <button
-          className="btn btn-primary"
-          onClick={() => handleSelectCategory("All")}
-        >
-          All
-        </button>
-        {Object.keys(TECH_CATEGORIES).map((category) => (
-          <button
-            key={category}
-            className={`btn ${
-              selectedCategory === category ? "btn-active" : "btn-secondary"
-            }`}
-            onClick={() => handleSelectCategory(category)}
-          >
-            {TECH_CATEGORIES[category as keyof typeof TECH_CATEGORIES]}
-          </button>
-        ))}
-      </div>
+    <section className="w-full py-16">
+      <div className="max-w-6xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+        <div className="flex gap-2 mb-4">
+          {/* Filter Buttons */}
 
-      {/* Card grid */}
-      <div className="flex flex-wrap gap-4">
-        {filteredTechItems.map((item: TechItem) => (
-          <TechStackCard key={item.name} name={item.name} Icon={item.Icon} />
-        ))}
+          <button
+            onClick={() => handleSelectCategory("All")}
+            className={`px-4 py-1 rounded-full text-sm font-medium transition-colors duration-200 ${
+              selectedCategory === "All"
+                ? "bg-[#00ABC9] text-[#0A192F]"
+                : "border border-[#00ABC9] text-[#00ABC9] hover:bg-[#00ABC9]/20 hover:text-white"
+            }`}
+          >
+            All
+          </button>
+          {Object.keys(TECH_CATEGORIES).map((category) => (
+            <button
+              key={category}
+              className={`btn px-3 py-1 rounded-full text-sm font-medium ${
+                selectedCategory === category
+                  ? "bg-[#00ABC9] text-[#0A192F]"
+                  : "border border-[#00ABC9] text-[#00ABC9]"
+              }`}
+              onClick={() => handleSelectCategory(category)}
+            >
+              {category}
+            </button>
+          ))}
+        </div>
+        {/* Card grid */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+          {filteredTechItems.map((item: TechItem) => (
+            <TechStackCard key={item.name} name={item.name} Icon={item.Icon} />
+          ))}
+        </div>
       </div>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
# Changelog: Tech-Stack Grid UI (feature/00-tech-stack-grid-ui)

## New “TechStackGrid” Section
- **Created** `src/components/sections/TechStack/data.ts`:
  - Defined `TECH_CATEGORIES` map & `ALL_TECH_ITEMS` array.
  - Switched to React-Icons: imported brand icons (SiReact, SiNextdotjs, etc.) and used `FiCode` as a fallback for Vuex/Zustand.
- **Built** `src/components/sections/TechStack/index.tsx`:
  - Stateful filter (`selectedCategory`) with buttons for **All**, **Frontend**, **Backend**, **State**, **Tools**.
  - Filter logic (`ALL_TECH_ITEMS.filter(...)`) drives which icons show.
  - Rendered each tech as a `<TechStackCard name={…} Icon={…} />`.

## Refactor “TechStackCard”
- **Updated** `src/components/ui/TechStackCard.tsx`:
  - Props changed from an array of logos to a single `{ name: string; Icon: IconType }`.
  - Renders one `<Icon size={40} />` and the tech name.
  - Removed Next.js `<Image>` usage here.

## Icon Library Swap
- **Removed** Heroicons across the app and replaced with React-Icons (Feather + SimpleIcons):
  - **TimelineCard**: `ChevronRightIcon` → `FiChevronRight`
  - **Navigation**: `Bars3Icon`/`XMarkIcon` → `FiMenu`/`FiX`
  - **Footer**: `EnvelopeIcon`/`CodeBracketIcon`/etc. → `FiMail`, `SiGithub`, `SiLinkedin`, `SiInstagram`
- **Enhanced** `FocusNode` in `components/ui/FocusEndFocus.tsx`:
  - Props now accept either `icon: IconType` or `logo: string` (fallback).
  - Conditionally renders `<Icon />` (if provided) or `<Image />`.

## Layout & Styling Improvements
- **Wrapped** Tech-Stack in a `<section class="w-full bg-[#0A192F] py-16">` → `<div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">` for consistent padding.
- **Buttons**:
  - Unified styling: `px-4 py-1 rounded-full text-sm font-medium transition-colors`.
  - Active vs. inactive states via `bg-[#00ABC9] text-[#0A192F]` vs. `border border-[#00ABC9] hover:bg-[#00ABC9]/20`.
- **Grid**:
  - Swapped `flex flex-wrap` to `grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6` for responsive layout.

---

> **Branch:** `feature/00-tech-stack-grid-ui`
